### PR TITLE
Use original SemanticKITTI colors

### DIFF
--- a/spvnas/visualize.py
+++ b/spvnas/visualize.py
@@ -121,6 +121,7 @@ cmap = np.array([
     [0, 0, 255, 255],
     #[255, 255, 255, 0]
 ])
+cmap = cmap[:, [2, 1, 0, 3]]  # convert bgra to rgba
 
 
 #cmap[:, -1] = 255


### PR DESCRIPTION
`cmap` defined in `visualize.py` is given in the original SemanticKITTI colors which is in `bgra`. To get the original colors in the visualization, the color map has to be converted into `rgba`.

Previous (`bgra` definition used instead of `rgba`):
![000000_bgr](https://user-images.githubusercontent.com/33211926/103751924-4bb4cd00-5009-11eb-9276-7a14dc7f0ff4.png)
Now (original SemanticKITTI colors):
![000000_rgb](https://user-images.githubusercontent.com/33211926/103751936-4fe0ea80-5009-11eb-9f0f-1940d812b19a.png)

