### PR TITLE
Bugfix: remove estimator for correct key in config

### DIFF
--- a/spvnas/core/builder.py
+++ b/spvnas/core/builder.py
@@ -48,7 +48,7 @@ def make_model() -> nn.Module:
             vres=configs.dataset.voxel_size
         )
     else:
-        raise NotImplementedError(configs.model.estimator.name)
+        raise NotImplementedError(configs.model.name)
     return model
 
 


### PR DESCRIPTION
Just a little bugfix. All configs are designed like this
```
model:
  name: ...
  ...
```
Change `configs.model.estimator.name` to `configs.model.name` for correct handling.